### PR TITLE
[FE] feat: modal review 전체적으로 수정

### DIFF
--- a/client/src/Components/Modal.tsx
+++ b/client/src/Components/Modal.tsx
@@ -280,7 +280,6 @@ const Modal = ({ click, setClick, id, bookmark }: CProps['clicks']) => {
   };
 
   const reviewEditCancelHandler = (commentId: number) => {
-    mapReviewUPDATE(commentId, editReview);
     setEditActivate(0);
     setTest(test + 1);
   };

--- a/client/src/Components/Modal.tsx
+++ b/client/src/Components/Modal.tsx
@@ -175,7 +175,7 @@ const Modal = ({ click, setClick, id, bookmark }: CProps['clicks']) => {
 
   const reviewHandler = (e: React.ChangeEvent<HTMLInputElement>): void => {
     setReview((e.target as HTMLInputElement).value);
-    console.log((e.target as HTMLInputElement).value);
+    console.log('reviewhandler', (e.target as HTMLInputElement).value);
   };
   const editReviewHandler = (e: React.ChangeEvent<HTMLInputElement>): void => {
     setEditReview((e.target as HTMLInputElement).value);
@@ -185,17 +185,30 @@ const Modal = ({ click, setClick, id, bookmark }: CProps['clicks']) => {
   const reviewPostHandler = () => {
     setTest(test + 1);
     mapReviewEdit(id, review);
-    console.log(test);
-    Swal.fire({
-      position: 'center',
-      icon: 'warning',
-      iconHtml: '🐾',
-      title: '작성되었습니다.',
-      color: brown,
-      padding: '20px 0px 40px 0px',
-      showConfirmButton: false,
-      timer: 1500,
-    });
+    console.log('test', test);
+    if (review === '') {      
+      Swal.fire({
+        position: 'center',
+        icon: 'warning',
+        iconHtml: '⚠',
+        title: '내용을 입력해주세요. ',
+        color: brown,
+        padding: '20px 0px 40px 0px',
+      });
+      return;
+    } else {
+      Swal.fire({
+        position: 'center',
+        icon: 'warning',
+        iconHtml: '🐾',
+        title: '작성되었습니다.',
+        color: brown,
+        padding: '20px 0px 40px 0px',
+        showConfirmButton: false,
+        timer: 1500,
+      });
+      setReview('');
+    }
   };
   const reviewUpdateHandler = (commentId: number) => {
     Swal.fire({

--- a/client/src/Components/Modal.tsx
+++ b/client/src/Components/Modal.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Icon } from '@iconify/react';
 import axios from 'axios';
 import Swal from 'sweetalert2';
-
+import { getUserInfo } from '../util/UserApi';
 import ModalSample from '../img/modalSample.svg';
 import UserImg1 from '../img/UserImg1.png';
 import color from '../color';
@@ -21,6 +21,15 @@ interface IReqData {
   infoMapId: number;
 }
 
+interface ResponseData {
+  petInfo: petInfo;
+}
+
+interface petInfo {
+  petName: string;
+  profileImage: File | null;
+}
+
 interface IReview {
   petId: number;
   commentId: number;
@@ -28,6 +37,15 @@ interface IReview {
   petName: string;
   contents: string;
   createdAt: string;
+}
+
+interface UserInfo {
+  petName: string;
+  profileImage: File | null;
+}
+
+interface FormData {
+  profileImage: Blob | null;
 }
 
 interface MapData {
@@ -79,6 +97,25 @@ const Modal = ({ click, setClick, id, bookmark }: CProps['clicks']) => {
       totalPages: 1,
     },
   });
+  const petId = localStorage.getItem('petId') as string;
+  const { responseData, error } = getUserInfo(petId);
+  const [info, setInfo] = useState<UserInfo>({
+    petName: '',
+    profileImage: null,
+  });
+
+  const [formData, setFormData] = useState<FormData>({ profileImage: null });
+  const [count, setCount] = useState<number>(0);
+
+  if (!error && responseData && count === 0) {
+    const { petInfo } = responseData as ResponseData;
+    const { petName, profileImage } = petInfo;
+    setInfo({ ...info, petName: petName });
+    setFormData({ profileImage: profileImage });
+    setCount(count + 1);
+  }
+
+  const UserImg = formData.profileImage as unknown as string;
 
   useEffect(() => {
     getData();
@@ -93,6 +130,7 @@ const Modal = ({ click, setClick, id, bookmark }: CProps['clicks']) => {
       .then((res) => {
         setResData(res.data);
         setMapdata(res.data);
+        console.log(res.data);
         setLoading(false);
       })
       .catch((error) => {
@@ -282,7 +320,7 @@ const Modal = ({ click, setClick, id, bookmark }: CProps['clicks']) => {
                           {el.commentId !== editActivate ? (
                             <ReviewWrite>
                               <ReviewUserBox>
-                                <ReviewUserImage src={UserImg1} />
+                                <ReviewUserImage src={el.profileImage} />
                                 <ReviewUserName>{el.petName}</ReviewUserName>
                               </ReviewUserBox>
                               <ReviewTextBox>
@@ -341,8 +379,8 @@ const Modal = ({ click, setClick, id, bookmark }: CProps['clicks']) => {
               {/* 리뷰 작성 */}
               <ReviewWrite>
                 <ReviewUserBox>
-                  <ReviewUserImage src={UserImg1} />
-                  <ReviewUserName>유저 이름</ReviewUserName>
+                  <ReviewUserImage src={UserImg} />
+                  <ReviewUserName>{info.petName}</ReviewUserName>
                 </ReviewUserBox>
                 <ReviewInputTextBox>
                   <ReviewInputBox>

--- a/client/src/Components/Modal.tsx
+++ b/client/src/Components/Modal.tsx
@@ -179,14 +179,14 @@ const Modal = ({ click, setClick, id, bookmark }: CProps['clicks']) => {
   };
   const editReviewHandler = (e: React.ChangeEvent<HTMLInputElement>): void => {
     setEditReview((e.target as HTMLInputElement).value);
-    console.log((e.target as HTMLInputElement).value);
+    console.log('editreviewhandler', (e.target as HTMLInputElement).value);
   };
 
   const reviewPostHandler = () => {
     setTest(test + 1);
     mapReviewEdit(id, review);
     console.log('test', test);
-    if (review === '') {      
+    if (review === '') {
       Swal.fire({
         position: 'center',
         icon: 'warning',
@@ -211,29 +211,43 @@ const Modal = ({ click, setClick, id, bookmark }: CProps['clicks']) => {
     }
   };
   const reviewUpdateHandler = (commentId: number) => {
-    Swal.fire({
-      title: '정말 수정하시겠어요?',
-      icon: 'warning',
-      showCancelButton: true,
-      color: brown,
-      confirmButtonColor: yellow,
-      cancelButtonColor: bordergrey,
-      confirmButtonText: '<b>확인</b>',
-      cancelButtonText: '<b>취소</b>',
-    }).then((result) => {
-      if (result.isConfirmed) {
-        Swal.fire({
-          title: '수정되었습니다.',
-          icon: 'success',
-          color: brown,
-          confirmButtonColor: yellow,
-          confirmButtonText: '<b>확인</b>',
-        });
-        mapReviewUPDATE(commentId, editReview);
-        setEditActivate(0);
-        setTest(test + 1);
-      }
-    });
+    console.log('editreview', editReview);
+    if (editReview === '') {
+      Swal.fire({
+        position: 'center',
+        icon: 'warning',
+        iconHtml: '⚠',
+        title: '내용을 입력해주세요. ',
+        color: brown,
+        padding: '20px 0px 40px 0px',
+      });
+      return;
+    } else {
+      Swal.fire({
+        title: '정말 수정하시겠어요?',
+        icon: 'warning',
+        showCancelButton: true,
+        color: brown,
+        confirmButtonColor: yellow,
+        cancelButtonColor: bordergrey,
+        confirmButtonText: '<b>확인</b>',
+        cancelButtonText: '<b>취소</b>',
+      }).then((result) => {
+        if (result.isConfirmed) {
+          Swal.fire({
+            title: '수정되었습니다.',
+            icon: 'success',
+            color: brown,
+            confirmButtonColor: yellow,
+            confirmButtonText: '<b>확인</b>',
+          });
+          mapReviewUPDATE(commentId, editReview);
+          setEditActivate(0);
+          setTest(test + 1);
+        }
+      });
+      setEditReview('');
+    }
   };
 
   const reviewDeleteHandler = (commentId: number) => {
@@ -263,6 +277,12 @@ const Modal = ({ click, setClick, id, bookmark }: CProps['clicks']) => {
   const reviewActivateHandler = (commentId: number) => {
     setEditActivate(commentId);
     console.log(editActivate);
+  };
+
+  const reviewEditCancelHandler = (commentId: number) => {
+    mapReviewUPDATE(commentId, editReview);
+    setEditActivate(0);
+    setTest(test + 1);
   };
   return (
     <div>
@@ -362,24 +382,35 @@ const Modal = ({ click, setClick, id, bookmark }: CProps['clicks']) => {
                           ) : (
                             <ReviewWrite>
                               <ReviewUserBox>
-                                <ReviewUserImage src={UserImg1} />
-                                <ReviewUserName>{el.username}</ReviewUserName>
+                                <ReviewUserImage src={el.profileImage} />
+                                <ReviewUserName>{el.petName}</ReviewUserName>
                               </ReviewUserBox>
                               <ReviewInputTextBox>
                                 <ReviewInputBox>
                                   <ReviewInput
                                     type='text'
-                                    placeholder={el.content}
+                                    placeholder={el.contents}
                                     onChange={editReviewHandler}
-                                  />
+                                    id='basereview'
+                                  >
+                                  </ReviewInput>
                                 </ReviewInputBox>
                                 <ReviewButton onClick={() => reviewUpdateHandler(el.commentId)}>
                                   <Icon
-                                    icon='material-symbols:check-small-rounded'
-                                    color={yellow}
+                                    icon='mdi:check-bold'
+                                    color='#ffc57e'
                                     style={{ fontSize: '20px' }}
                                   />
                                 </ReviewButton>
+                                <ReviewEditCancelButton
+                                  onClick={() => reviewEditCancelHandler(el.commentId)}
+                                >
+                                  <Icon
+                                    icon='mdi:cancel-bold'
+                                    color='#f79483'
+                                    style={{ fontSize: '22px' }}
+                                  />
+                                </ReviewEditCancelButton>
                               </ReviewInputTextBox>
                             </ReviewWrite>
                           )}
@@ -635,9 +666,9 @@ const ReviewInput = styled.input<Props>`
   }
 `;
 const ReviewButton = styled.button`
-  margin-left: 8px;
+  margin-left: 4px;
+  margin-right: 4px;
   padding: 7px 10px;
-  font-size: 14px;
   font-weight: bold;
   background: ${brown};
   border-radius: 12px;
@@ -701,6 +732,20 @@ const EditDelButtons = styled.div`
       color: ${yellow};
       background-color: ${ivory};
     }
+  }
+`;
+
+const ReviewEditCancelButton = styled.button`
+  padding: 7px 10px;
+  font-weight: bold;
+  background: ${ivory};
+  border-radius: 12px;
+  border: 1px solid ${bordergrey};
+  color: white;
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${darkbrown};
   }
 `;
 

--- a/client/src/Components/Modal.tsx
+++ b/client/src/Components/Modal.tsx
@@ -279,9 +279,9 @@ const Modal = ({ click, setClick, id, bookmark }: CProps['clicks']) => {
     console.log(editActivate);
   };
 
-  const reviewEditCancelHandler = (commentId: number) => {
+  const reviewEditCancelHandler = () => {
     setEditActivate(0);
-    setTest(test + 1);
+    setEditReview('');
   };
   return (
     <div>
@@ -402,7 +402,7 @@ const Modal = ({ click, setClick, id, bookmark }: CProps['clicks']) => {
                                   />
                                 </ReviewButton>
                                 <ReviewEditCancelButton
-                                  onClick={() => reviewEditCancelHandler(el.commentId)}
+                                  onClick={reviewEditCancelHandler}
                                 >
                                   <Icon
                                     icon='mdi:cancel-bold'

--- a/client/src/Components/Modal.tsx
+++ b/client/src/Components/Modal.tsx
@@ -263,7 +263,7 @@ const Modal = ({ click, setClick, id, bookmark }: CProps['clicks']) => {
             <FlexBox>
               <InfoDiv>
                 {/* 사진 */}
-                <Image src={ModalSample} />
+                <Image src={mapdata.details.infoUrl} />
 
                 {/* 이름 */}
                 <InfoTitleBox>


### PR DESCRIPTION
### 작업 사항
- Modal - 로그인한 후에 접속시 리뷰작성칸 유저이름, 프로필 로그인한 유저로 수정
- Modal - reviewPostHandler에서 리뷰가 빈칸일 때는 작성 못하게 수정
- modal default값 바꾸기
- 댓글 수정 눌렀을 때, 댓글 수정 취소 버튼

### 스크린샷
리뷰작성 유저이름 변경
![image](https://user-images.githubusercontent.com/58413633/214776664-a4108faf-4a2f-4844-ae1b-3d47e552da4c.png)

review 내용 없는 상태로 작성시 alert 
![image](https://user-images.githubusercontent.com/58413633/214780665-7cc27d7b-68ea-4f8f-885f-4a6e0c544b00.png)

리뷰 수정 취소 버튼
![image](https://user-images.githubusercontent.com/58413633/214790808-faa2fff3-ceb5-442c-9131-07f886897a1a.png)

